### PR TITLE
Fixed displaying icons for files. Added default icons for default directories. Fixed problem with makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 RANGER_DIR=$(if $(XDG_CONFIG_HOME),$(XDG_CONFIG_HOME),$(HOME)/.config)/ranger
 PLUGIN_DIR=$(RANGER_DIR)/plugins
+RC_FILE=$(RANGER_DIR)/rc.conf
+DEVICONS_IN_RC="default_linemode devicons"
 
 install:
 	install -d $(PLUGIN_DIR)
 	install -b devicons.py $(RANGER_DIR)/devicons.py
 	install -b devicons_linemode.py $(PLUGIN_DIR)/devicons_linemode.py
-	echo "default_linemode devicons" >> $(RANGER_DIR)/rc.conf
+	grep -q $(DEVICONS_IN_RC) $(RC_FILE) || echo $(DEVICONS_IN_RC) >> $(RC_FILE)
 
 uninstall:
 	$(RM) $(RANGER_DIR)/devicons.py

--- a/devicons.py
+++ b/devicons.py
@@ -86,6 +86,7 @@ file_node_extensions = {
     'erl'      : '',
     'hrl'      : '',
     'vim'      : '',
+    'vimrc'    : '',
     'ai'       : '',
     'psd'      : '',
     'psb'      : '',
@@ -126,6 +127,19 @@ file_node_extensions = {
     'zip'      : ''
 }
 
+dir_node_exact_matches = {
+    '.git'                             : '',
+    'Desktop'                          : '',
+    'Documents'                        : '',
+    'Downloads'                        : '',
+    'Dropbox'                          : '',
+    'Music'                            : '',
+    'Pictures'                         : '',
+    'Public'                           : '',
+    'Templates'                        : '',
+    'Videos'                           : '',
+}
+
 file_node_exact_matches = {
     'exact-match-case-sensitive-1.txt' : 'X1',
     'exact-match-case-sensitive-2'     : 'X2',
@@ -158,7 +172,7 @@ file_node_exact_matches = {
     '.profile'                         : '',
     '.recently-used'                   : '',
     '.selected_editor'                 : '',
-    '.vimrc'                           : '',
+    '.vimrc'                           : '',
     '.xinputrc'                        : '',
     'mimeapps.list'                    : '',
     'user-dirs.dirs'                   : '',
@@ -167,5 +181,5 @@ file_node_exact_matches = {
 }
 
 def devicon(file):
-  if file.is_directory: return ''
+  if file.is_directory: return dir_node_exact_matches.get(file.relative_path, '')
   return file_node_exact_matches.get(file.relative_path, file_node_extensions.get(file.extension, ''))

--- a/devicons_linemode.py
+++ b/devicons_linemode.py
@@ -3,10 +3,17 @@ from ranger.core.linemode import LinemodeBase
 from devicons import *
 
 @ranger.api.register_linemode
-class DevIconsLinemode(ranger.core.linemode.LinemodeBase):
+class DevIconsLinemode(LinemodeBase):
   name = "devicons"
 
   uses_metadata = False
+
+  def filetitle(self, file, metadata):
+    return devicon(file) + ' ' + file.relative_path
+
+@ranger.api.register_linemode
+class DevIconsLinemodeFile(LinemodeBase):
+  name = "filename"
 
   def filetitle(self, file, metadata):
     return devicon(file) + ' ' + file.relative_path


### PR DESCRIPTION
* Fixed displaying icons for files:
After installation `ranger_devicons`, it worked only for directories. I created new class `DevIconsLinemodeFile` where I reimplemented method `filetitle` for filenames.
* Added default icons for default directories.
* Fixed problem with makefile:
Now makefile will add call of devicons to rc.conf only one time.