### PR TITLE
Add support for Ranger update that loads directories in plugin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+.mypy_cache/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ RC_FILE=$(RANGER_DIR)/rc.conf
 install:
 	install -d $(PLUGIN_DIR)
 	install -b devicons.py $(PLUGIN_DIR)/devicons.py
-	install -b devicons_linemode.py $(PLUGIN_DIR)/devicons_linemode.py
+	install -b __init__.py $(PLUGIN_DIR)/devicons_linemode.py
 	grep -q 'default_linemode devicons' $(RC_FILE) || echo '# a plugin that adds file glyphs / icon support to Ranger:' >> $(RC_FILE)
 	grep -q 'default_linemode devicons' $(RC_FILE) || echo '# https://github.com/alexanderjeurissen/ranger_devicons' >> $(RC_FILE)
 	grep -q 'default_linemode devicons' $(RC_FILE) || echo 'default_linemode devicons' >> $(RC_FILE)

--- a/README.md
+++ b/README.md
@@ -13,5 +13,14 @@ screenshot), this and other NERDfonts and the install instructions for these fon
 the following repository: https://github.com/ryanoasis/nerd-fonts
 
 ## Install instructions
+### Stable method:
 A makefile is included to install and uninstall this plugin. to install simply run:
 `make install` and to uninstall the plugin run `make uninstall`.
+
+### Experimental method:
+Ranger has added support for loading directories in the plugins folder to `master` which makes it easier to install and keep plugins updated.  
+To install, just clone the repo into the plugins folder:
+```bash
+git clone https://github.com/alexanderjeurissen/ranger_devicons ~/.config/ranger/plugins/ranger_devicons
+```
+Then add `default_linemode devicons` to your `rc.conf`.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 import ranger.api
 from ranger.core.linemode import LinemodeBase
-from plugins.devicons import *
+from .devicons import *
 
 @ranger.api.register_linemode
 class DevIconsLinemode(LinemodeBase):


### PR DESCRIPTION
Ranger added support for loading directories in the plugin folder to master in https://github.com/ranger/ranger/commit/994b541f5c91651f7cf25776abddd66159f4886b. This should make it easier to install and update plugins, since you can just `git clone` to the plugin folder to install, and `git pull` to update. The only requirement is the entry python file has to be named `__init__.py`.

This can also probably close #24 and #15.