### PR TITLE
fix Dropbox icon

### DIFF
--- a/devicons.py
+++ b/devicons.py
@@ -176,7 +176,7 @@ dir_node_exact_matches = {
     'Documents'                        : '',
     'Downloads'                        : '',
     'Dotfiles'                         : '',
-    'Dropbox'                          : '',
+    'Dropbox'                          : '',
     'Music'                            : '',
     'Pictures'                         : '',
     'Public'                           : '',


### PR DESCRIPTION
the last commit need more review, for example, Dropbox icon is not proper
you can change the icon with  for bigger font