### PR TITLE
Fix exact match for flat level

### DIFF
--- a/devicons.py
+++ b/devicons.py
@@ -319,4 +319,4 @@ file_node_exact_matches = {
 
 def devicon(file):
   if file.is_directory: return dir_node_exact_matches.get(file.relative_path, '')
-  return file_node_exact_matches.get(file.relative_path, file_node_extensions.get(file.extension, ''))
+  return file_node_exact_matches.get(os.path.basename(file.relative_path), file_node_extensions.get(file.extension, ''))


### PR DESCRIPTION
Exact match doesn't work at flat level (level >= 1).