### PR TITLE
Add .pyo files to gitignore and add .hpp extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
+*.pyo
 .mypy_cache/

--- a/devicons.py
+++ b/devicons.py
@@ -78,6 +78,7 @@ file_node_extensions = {
     'gzip'     : '',
     'h'        : '',
     'hbs'      : '',
+    'hpp'      : '',
     'hrl'      : '',
     'hs'       : '',
     'htaccess' : '',


### PR DESCRIPTION
Ranger seems to generate `.pyo` files in the `plugins/ranger_devicons` directory, which show up as untracked files when adding the plugin as a submodule.

I track my ranger config files by storing them in a git repo, and adding plugins in the `plugins/` directory as submodules. Since, ranger generates these `.pyo` files, these always show up as untracked files in my primary ranger config file repo, but these files can't be discarded as ranger just regenerates the files anyways and can't be added in a commit without going out of sync with `alexanderjeurissen/ranger_devicons`.