### PR TITLE
Make separator configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ git clone https://github.com/alexanderjeurissen/ranger_devicons ~/.config/ranger
 ```
 
 Then execute the following `echo "default_linemode devicons" >> $HOME/.config/ranger/rc.conf` (or wherever your `rc.conf` is located).
+
+## Configuration
+This plugin can be configured by setting environment variables (e.g. in your
+`~/.profile`). Currently, only one option is available:
+
+- `RANGER_DEVICONS_SEPARATOR` (default `" "`, i.e. a single space): The
+  separator between icon and filename. Some terminals use the adjacent space to
+  display a bigger icon, in which case this can be set to two spaces instead.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,9 @@
+import os
 import ranger.api
 from ranger.core.linemode import LinemodeBase
 from .devicons import *
+
+SEPARATOR = os.getenv('RANGER_DEVICONS_SEPARATOR', ' ')
 
 @ranger.api.register_linemode
 class DevIconsLinemode(LinemodeBase):
@@ -9,4 +12,4 @@ class DevIconsLinemode(LinemodeBase):
   uses_metadata = False
 
   def filetitle(self, file, metadata):
-    return devicon(file) + ' ' + file.relative_path
+    return devicon(file) + SEPARATOR + file.relative_path


### PR DESCRIPTION
Some terminals, such as kitty, use the space after icons to merge the two cells and display a bigger icon:

![image](https://user-images.githubusercontent.com/625793/120848591-438b9a00-c575-11eb-93db-cdb8931bd02f.png)

For nicer rendering in this case, two spaces can be used as separator instead:

![image](https://user-images.githubusercontent.com/625793/120848742-759cfc00-c575-11eb-8b8e-eebb4f91cb30.png)

For more context, see e.g.:

https://github.com/ogham/exa/pull/619
https://github.com/Peltoche/lsd/issues/363

It looks like there [isn't a straightforward way](https://github.com/ranger/ranger/blob/v1.9.3/ranger/container/settings.py#L26) for a plugin to add a new config option to ranger, so I went with an environment variable instead.

What do you think? If this sounds reasonable, I'll expand the readme a bit to document it.