### PR TITLE
Feat: patch ranger's builtin linemodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,20 @@ git clone --depth=1 https://github.com/alexanderjeurissen/ranger_devicons ~/.con
 ## Configuration
 
 This plugin can be configured by setting environment variables (e.g. in your
-`~/.profile`). Currently, only one option is available:
+`~/.profile`).
 
 - `RANGER_DEVICONS_SEPARATOR` (default `" "`, i.e. a single space): The
   separator between icon and filename. Some terminals use the adjacent space to
   display a bigger icon, in which case this can be set to two spaces instead.
+
+- `RANGER_DEVICONS_PATCH_BUILTIN` (default `True`): Whether to patch Ranger's
+  builtin linemodes, i.e., prefixes all builtin linemodes with file icons. You
+  can set `RANGER_DEVICONS_PATCH_BUILTIN="False"` to disable this and execute the
+  following command:
+
+  ```bash
+  echo "default_linemode devicons" >> "$HOME/.config/ranger/rc.conf"
+  ```
+
+  to use the devicons linemode (which is identical to the patched version of Ranger's
+  default linemode).

--- a/README.md
+++ b/README.md
@@ -31,14 +31,20 @@ This plugin can be configured by setting environment variables (e.g. in your
   separator between icon and filename. Some terminals use the adjacent space to
   display a bigger icon, in which case this can be set to two spaces instead.
 
-- `RANGER_DEVICONS_PATCH_BUILTIN` (default `True`): Whether to patch Ranger's
-  builtin linemodes, i.e., prefixes all builtin linemodes with file icons. You
-  can set `RANGER_DEVICONS_PATCH_BUILTIN="False"` to disable this and execute the
+- `RANGER_DEVICONS_OVERRIDE_BUILTIN` (default `True`): Whether to override Ranger's
+  builtin linemodes with patches, i.e., prefixes all builtin linemodes with file icons.
+  You can set `RANGER_DEVICONS_OVERRIDE_BUILTIN="False"` to disable this and execute the
   following command:
 
   ```bash
-  echo "default_linemode devicons" >> "$HOME/.config/ranger/rc.conf"
+  echo "default_linemode devicons" >> "${HOME}/.config/ranger/rc.conf"
   ```
 
   to use the devicons linemode (which is identical to the patched version of Ranger's
   default linemode).
+
+  Or (Ranger's builtin linemodes with prefix `devicons-`):
+
+  ```bash
+  echo "default_linemode devicons-filename" >> "${HOME}/.config/ranger/rc.conf"
+  ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This plugin introduces a new linemode that prefixes file names with a file icon
 ![image](screenshot.png)
 
 ## Prerequisites
+
 This plugin uses glyphs from a patched NERDfont. So in order for this plugin to work you need to
 install a NERDfont and set it as the default font for your terminal.
 
@@ -13,15 +14,16 @@ screenshot), this and other NERDfonts and the install instructions for these fon
 the following repository: https://github.com/ryanoasis/nerd-fonts
 
 ## Install instructions
+
 Ranger has added support for loading directories in the plugins folder which makes it easier to install and keep plugins updated.
 To install, just clone the repo into the plugins folder:
+
 ```bash
-git clone https://github.com/alexanderjeurissen/ranger_devicons ~/.config/ranger/plugins/ranger_devicons
+git clone --depth=1 https://github.com/alexanderjeurissen/ranger_devicons ~/.config/ranger/plugins/ranger_devicons
 ```
 
-Then execute the following `echo "default_linemode devicons" >> $HOME/.config/ranger/rc.conf` (or wherever your `rc.conf` is located).
-
 ## Configuration
+
 This plugin can be configured by setting environment variables (e.g. in your
 `~/.profile`). Currently, only one option is available:
 

--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,7 @@ def patch_devicons(base, classname=None, attributes=None):
     """Patch a linemode class with file icons."""
 
     classname = classname or base.__name__
-    attributes = attributes or {}
+    attributes = (attributes or {}).copy()
 
     def filetitle(self, file, metadata):
         """Prefix a file icon to the file title."""
@@ -24,7 +24,10 @@ def patch_devicons(base, classname=None, attributes=None):
             super(self.__class__, self).filetitle(file, metadata)
         ))
 
-    return type(classname, (base,), {'filetitle': filetitle, **attributes})
+    # Python 2.x-3.4 don't support unpacking syntex `{**dict}`
+    attributes['filetitle'] = filetitle
+
+    return type(classname, (base,), attributes)
 
 
 # Identical to patched DefaultLinemode(name='filename')

--- a/__init__.py
+++ b/__init__.py
@@ -4,10 +4,12 @@ from ranger.core import linemode
 from .devicons import *
 
 
+# User configurations
 SEPARATOR = os.getenv('RANGER_DEVICONS_SEPARATOR', ' ')
-PATCH_BUILTIN = (os.getenv('RANGER_DEVICONS_PATCH_BUILTIN', 'True').lower() in ('true', 'yes', '1'))
+OVERRIDE_BUILTIN = (os.getenv('RANGER_DEVICONS_OVERRIDE_BUILTIN', 'True').lower() in ('true', 'yes', '1'))
 
 
+# Make patched linemode class
 def patch_devicons(base, classname=None, attributes=None):
     """Patch a linemode class with file icons."""
 
@@ -27,26 +29,34 @@ def patch_devicons(base, classname=None, attributes=None):
     # Python 2.x-3.4 don't support unpacking syntex `{**dict}`
     attributes['filetitle'] = filetitle
 
-    return type(classname, (base,), attributes)
+    return type(classname, (base,), attributes)  # make subclass
 
 
-# Identical to patched DefaultLinemode(name='filename')
+# Add `DevIconsLinemode` linemode class
+# Identical to patched DefaultLinemode(name='filename') (i.e., `devicons-filename`)
 DevIconsLinemode = register_linemode(patch_devicons(base=linemode.DefaultLinemode,
                                                     classname='DevIconsLinemode',
                                                     attributes={'name': 'devicons'}))
 
 
-if PATCH_BUILTIN:
-    name, member = None, None
-    for name, member in vars(linemode).items():
-        if name.endswith('Linemode'):
-            try:
-                if not issubclass(member, linemode.LinemodeBase):
-                    continue
-            except TypeError:
+# Patch ranger's builtin linemodes with prefix `devicons-`
+name, linemode_class, new_name, new_classname = None, None, None, None
+for name, linemode_class in vars(linemode).items():
+    if name.endswith('Linemode'):
+        try:
+            if not issubclass(linemode_class, linemode.LinemodeBase):
                 continue
-            else:
-                # Patch ranger's builtin linemodes
-                globals()[name] = register_linemode(patch_devicons(base=member))
+        except TypeError:
+            continue
+        else:
+            # Patch ranger's builtin linemodes with prefix `devicons-`
+            new_name = 'devicons-' + linemode_class.name          # e.g., fileinfo         -> devicons-fileinfo
+            new_classname = 'DevIcons' + linemode_class.__name__  # e.g., FileInfoLinemode -> DevIconsFileInfoLinemode
+            globals()[new_name] = register_linemode(patch_devicons(base=linemode_class,
+                                                                  classname=new_classname,
+                                                                  attributes={'name': new_name}))
 
-    del name, member
+            if OVERRIDE_BUILTIN: # Override ranger's builtin linemodes
+                globals()[name] = register_linemode(patch_devicons(base=linemode_class))
+
+del name, linemode_class, new_name, new_classname

--- a/__init__.py
+++ b/__init__.py
@@ -1,15 +1,35 @@
 import os
 import ranger.api
-from ranger.core.linemode import LinemodeBase
+from ranger.core import linemode
 from .devicons import *
 
 SEPARATOR = os.getenv('RANGER_DEVICONS_SEPARATOR', ' ')
 
+
 @ranger.api.register_linemode
-class DevIconsLinemode(LinemodeBase):
-  name = "devicons"
+class DevIconsLinemode(linemode.LinemodeBase):
+    name = "devicons"
+    uses_metadata = False
 
-  uses_metadata = False
+    def filetitle(self, file, metadata):
+        return SEPARATOR.join((devicon(file), file.relative_path))
 
-  def filetitle(self, file, metadata):
-    return devicon(file) + SEPARATOR + file.relative_path
+
+def patch_devicons(cls):
+    def filetitle(self, file, metadata):
+        return SEPARATOR.join((devicon(file),
+                               super(self.__class__, self).filetitle(file, metadata)))
+
+    return type(cls.__name__, (cls,), {'filetitle': filetitle})
+
+
+name, attr = None, None
+for name, attr in vars(linemode).items():
+    if name.endswith('Linemode'):
+        try:
+            if issubclass(attr, linemode.LinemodeBase):
+                globals()[name] = ranger.api.register_linemode(patch_devicons(attr))
+        except TypeError:
+            pass
+
+del name, attr


### PR DESCRIPTION
Patch all ranger's builtin linemodes, such as `SizeMtimeLinemode`, `SizeHumanReadableMtimeLinemode`, etc. These patches make `DevIconsLinemode` identical to the patched default linemode, which simplifies the installation instructions (just a single `git clone` command).

![screencast](https://user-images.githubusercontent.com/16078332/132681080-702aea63-a304-4ba8-ab11-789f1ced6475.gif)
