### PR TITLE
fix XDG env access

### DIFF
--- a/devicons.py
+++ b/devicons.py
@@ -8,22 +8,16 @@ import os;
 
 # Get the XDG_USER_DIRS directory names from enviromental variables
 
-XDG_DOCUMENTS_DIR = os.getenv('XDG_DOCUMENTS_DIR', default=' ')
-XDG_DOCUMENTS_DIR = XDG_DOCUMENTS_DIR.split('/')[-2]
-XDG_DOWNLOAD_DIR = os.getenv('XDG_DOWNLOAD_DIR', default=' ')
-XDG_DOWNLOAD_DIR = XDG_DOWNLOAD_DIR.split('/')[-2]
-XDG_CONFIG_DIR = os.getenv('XDG_CONFIG_DIR', default=' ')
-XDG_CONFIG_DIR = XDG_CONFIG_DIR.split('/')[-2]
-XDG_MUSIC_DIR = os.getenv('XDG_MUSIC_DIR', default=' ')
-XDG_MUSIC_DIR = XDG_MUSIC_DIR.split('/')[-2]
-XDG_PICTURES_DIR = os.getenv('XDG_PICTURES_DIR', default=' ')
-XDG_PICTURES_DIR = XDG_PICTURES_DIR.split('/')[-2]
-XDG_PUBLICSHARE_DIR = os.getenv('XDG_PUBLICSHARE_DIR', default=' ')
-XDG_PUBLICSHARE_DIR = XDG_PUBLICSHARE_DIR.split('/')[-2]
-XDG_TEMPLATES_DIR = os.getenv('XDG_TEMPLATES_DIR', default=' ')
-XDG_TEMPLATES_DIR = XDG_TEMPLATES_DIR.split('/')[-2]
-XDG_VIDEOS_DIR = os.getenv('XDG_VIDEOS_DIR', default=' ')
-XDG_VIDEOS_DIR = XDG_VIDEOS_DIR.split('/')[-2]
+xdgs_dirs = {path.split('/')[-2]: icon for key, icon in [
+    ('XDG_DOCUMENTS_DIR'  , ''),
+    ('XDG_DOWNLOAD_DIR'   , ''),
+    ('XDG_CONFIG_DIR'     , ''),
+    ('XDG_MUSIC_DIR'      , ''),
+    ('XDG_PICTURES_DIR'   , ''),
+    ('XDG_PUBLICSHARE_DIR', ''),
+    ('XDG_TEMPLATES_DIR'  , ''),
+    ('XDG_VIDEOS_DIR'     , ''),
+] if (path := os.getenv(key))}
 
 
 # all those glyphs will show as weird squares if you don't have the correct patched font
@@ -224,15 +218,6 @@ file_node_extensions = {
 }
 
 dir_node_exact_matches = {
-# XDG_USER_DIRS
-    XDG_DOCUMENTS_DIR                  : '',
-    XDG_DOWNLOAD_DIR                   : '',
-    XDG_CONFIG_DIR                     : '',
-    XDG_MUSIC_DIR                      : '',
-    XDG_PICTURES_DIR                   : '',
-    XDG_PUBLICSHARE_DIR                : '',
-    XDG_TEMPLATES_DIR                  : '',
-    XDG_VIDEOS_DIR                     : '',
 # English
     '.git'                             : '',
     'Desktop'                          : '',
@@ -294,6 +279,8 @@ dir_node_exact_matches = {
     'Letöltések'                       : '',
     'Számítógép'                       : '',
     'Videók'                           : '',
+# XDG_USER_DIRS
+    **xdgs_dirs
 }
 
 file_node_exact_matches = {


### PR DESCRIPTION
The xdg env variables were mistreated after being fetch. This do badly
when no such variables exists.

Should fix #92 MR for issue #94.

/!\ only works in python >= 3.8