### PR TITLE
Improve Python version compatibility

### DIFF
--- a/devicons.py
+++ b/devicons.py
@@ -3,21 +3,26 @@
 # These glyphs, and the mapping of file extensions to glyphs
 # has been copied from the vimscript code that is present in
 # https://github.com/ryanoasis/vim-devicons
-import re;
-import os;
 
-# Get the XDG_USER_DIRS directory names from enviromental variables
+import re
+import os
 
-xdgs_dirs = {path.split('/')[-2]: icon for key, icon in [
-    ('XDG_DOCUMENTS_DIR'  , ''),
-    ('XDG_DOWNLOAD_DIR'   , ''),
-    ('XDG_CONFIG_DIR'     , ''),
-    ('XDG_MUSIC_DIR'      , ''),
-    ('XDG_PICTURES_DIR'   , ''),
-    ('XDG_PUBLICSHARE_DIR', ''),
-    ('XDG_TEMPLATES_DIR'  , ''),
-    ('XDG_VIDEOS_DIR'     , ''),
-] if (path := os.getenv(key))}
+
+# Get the XDG_USER_DIRS directory names from environment variables
+xdgs_dirs = {
+    os.path.basename(os.getenv(key).rstrip('/')): icon
+    for key, icon in (
+        ('XDG_DOCUMENTS_DIR', ''),
+        ('XDG_DOWNLOAD_DIR', ''),
+        ('XDG_CONFIG_DIR', ''),
+        ('XDG_MUSIC_DIR', ''),
+        ('XDG_PICTURES_DIR', ''),
+        ('XDG_PUBLICSHARE_DIR', ''),
+        ('XDG_TEMPLATES_DIR', ''),
+        ('XDG_VIDEOS_DIR', ''),
+    )
+    if os.getenv(key)
+}
 
 
 # all those glyphs will show as weird squares if you don't have the correct patched font
@@ -217,6 +222,7 @@ file_node_extensions = {
     'zsh'      : '',
 }
 
+
 dir_node_exact_matches = {
 # English
     '.git'                             : '',
@@ -282,6 +288,7 @@ dir_node_exact_matches = {
 # XDG_USER_DIRS
     **xdgs_dirs
 }
+
 
 file_node_exact_matches = {
     '.bash_aliases'                    : '',
@@ -374,6 +381,9 @@ file_node_exact_matches = {
     'webpack.config.js'                : '',
 }
 
+
 def devicon(file):
-  if file.is_directory: return dir_node_exact_matches.get(file.relative_path, '')
-  return file_node_exact_matches.get(os.path.basename(file.relative_path), file_node_extensions.get(file.extension, ''))
+    if file.is_directory:
+        return dir_node_exact_matches.get(file.relative_path, '')
+    return file_node_exact_matches.get(os.path.basename(file.relative_path),
+                                       file_node_extensions.get(file.extension, ''))

--- a/devicons.py
+++ b/devicons.py
@@ -285,9 +285,11 @@ dir_node_exact_matches = {
     'Letöltések'                       : '',
     'Számítógép'                       : '',
     'Videók'                           : '',
-# XDG_USER_DIRS
-    **xdgs_dirs
 }
+
+# Python 2.x-3.4 don't support unpacking syntex `{**dict}`
+# XDG_USER_DIRS
+dir_node_exact_matches.update(xdgs_dirs)
 
 
 file_node_exact_matches = {


### PR DESCRIPTION
Ranger supports Python 2.6, 2.7, and 3.x.

1. Remove syntax `:=` (require Python 3.8+) [PEP 572 -- Assignment Expressions](https://www.python.org/dev/peps/pep-0572).
    Commented in https://github.com/alexanderjeurissen/ranger_devicons/pull/95#discussion_r721560101.

    Fix #98.

2. Remove syntax `{**dict}` unpacking (require Python 3.5+) [PEP 448 -- Additional Unpacking Generalizations](https://www.python.org/dev/peps/pep-0448).

------

This PR has been tested on Python 2.7.