### PR TITLE
feat: add svelte icon

### DIFF
--- a/devicons.py
+++ b/devicons.py
@@ -207,6 +207,7 @@ file_node_extensions = {
     'sql'      : '',
     'styl'     : '',
     'suo'      : '',
+    'svelte'   : '',
     'swift'    : '',
     't'        : '',
     'tar'      : '',


### PR DESCRIPTION
Hi, Thank you for making this plugin!

I notice that the plugin doesn't show svelte icon correctly for svelte file extension when I was working on a svelte project. It turns out that the icon hasn't been added to the plugin yet.

This commit will add svelte icon to `file_node_extensions` to fix the issue.