### PR TITLE
Use I18N for lookup of exact directory matches in different locales

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -120,3 +120,29 @@ merged:
 
 10. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
     with a clear title and description.
+
+## Locale Support
+
+This project supports I18n for directory name to icon mappings. Locale files are created for each language listed in `devicons.py`. The `devicon` function retrieves the locale file for the current locale and the English locale. It then looks up `file.relative_path` inside the current locale to determine the English directory mapping name (only if the current locale is not English). Finally, it looks up the English directory mapping name in the English locale to retrieve the icon.
+
+### Adding New Locale Files
+
+To add a new locale file, follow these steps:
+
+1. Create a new file in the `locales` directory with the appropriate locale code (e.g., `locales/ja.yml` for Japanese).
+2. Add directory mappings for the new locale. The mappings should map the directory names in the new locale to the English directory names.
+
+Example:
+
+```yaml
+ja:
+  directory_mappings:
+    'デスクトップ': 'Desktop'
+    'ドキュメント': 'Documents'
+    'ダウンロード': 'Downloads'
+    '音楽': 'Music'
+    '画像': 'Pictures'
+    '公開': 'Public'
+    'テンプレート': 'Templates'
+    'ビデオ': 'Videos'
+```

--- a/README.md
+++ b/README.md
@@ -30,3 +30,29 @@ This plugin can be configured by setting environment variables (e.g. in your
 - `RANGER_DEVICONS_SEPARATOR` (default `" "`, i.e. a single space): The
   separator between icon and filename. Some terminals use the adjacent space to
   display a bigger icon, in which case this can be set to two spaces instead.
+
+## Locale Support
+
+This plugin supports I18n for directory name to icon mappings. Locale files are created for each language listed in `devicons.py`. The `devicon` function retrieves the locale file for the current locale and the English locale. It then looks up `file.relative_path` inside the current locale to determine the English directory mapping name (only if the current locale is not English). Finally, it looks up the English directory mapping name in the English locale to retrieve the icon.
+
+### Adding New Locale Files
+
+To add a new locale file, follow these steps:
+
+1. Create a new file in the `locales` directory with the appropriate locale code (e.g., `locales/ja.yml` for Japanese).
+2. Add directory mappings for the new locale. The mappings should map the directory names in the new locale to the English directory names.
+
+Example:
+
+```yaml
+ja:
+  directory_mappings:
+    'デスクトップ': 'Desktop'
+    'ドキュメント': 'Documents'
+    'ダウンロード': 'Downloads'
+    '音楽': 'Music'
+    '画像': 'Pictures'
+    '公開': 'Public'
+    'テンプレート': 'Templates'
+    'ビデオ': 'Videos'
+```

--- a/devicons.py
+++ b/devicons.py
@@ -6,7 +6,19 @@
 
 import re
 import os
+import yaml
 
+# Load locale files
+def load_locale(locale):
+    with open(f'locales/{locale}.yml', 'r', encoding='utf-8') as file:
+        return yaml.safe_load(file)
+
+# Get the current locale
+current_locale = os.getenv('LANG', 'en').split('.')[0]
+
+# Load the current locale and English locale
+current_locale_data = load_locale(current_locale)
+english_locale_data = load_locale('en')
 
 # Get the XDG_USER_DIRS directory names from environment variables
 xdgs_dirs = {
@@ -254,103 +266,6 @@ file_node_extensions = {
 }
 
 
-dir_node_exact_matches = {
-# English
-    '.git'                             : '',
-    'Desktop'                          : '',
-    'Documents'                        : '',
-    'Downloads'                        : '',
-    'Dotfiles'                         : '',
-    'Dropbox'                          : '',
-    'Music'                            : '',
-    'Pictures'                         : '',
-    'Public'                           : '',
-    'Templates'                        : '',
-    'Videos'                           : '',
-    'anaconda3'                        : '',
-    'go'                               : '',
-    'workspace'                        : '',
-    'OneDrive'                         : '',
-# Spanish
-    'Escritorio'                       : '',
-    'Documentos'                       : '',
-    'Descargas'                        : '',
-    'Música'                           : '',
-    'Imágenes'                         : '',
-    'Público'                          : '',
-    'Plantillas'                       : '',
-    'Vídeos'                           : '',
-# French
-    'Bureau'                           : '',
-    'Documents'                        : '',
-    'Images'                           : '',
-    'Musique'                          : '',
-    'Publique'                         : '',
-    'Téléchargements'                  : '',
-    'Vidéos'                           : '',
-# Portuguese
-    'Documentos'                       : '',
-    'Imagens'                          : '',
-    'Modelos'                          : '',
-    'Música'                           : '',
-    'Público'                          : '',
-    'Vídeos'                           : '',
-    'Área de trabalho'                 : '',
-# Italian
-    'Documenti'                        : '',
-    'Immagini'                         : '',
-    'Modelli'                          : '',
-    'Musica'                           : '',
-    'Pubblici'                         : '',
-    'Scaricati'                        : '',
-    'Scrivania'                        : '',
-    'Video'                            : '',
-# German
-    'Bilder'                           : '',
-    'Dokumente'                        : '',
-    'Musik'                            : '',
-    'Schreibtisch'                     : '',
-    'Vorlagen'                         : '',
-    'Öffentlich'                       : '',
-# Hungarian
-    'Dokumentumok'                     : '',
-    'Képek'                            : '',
-    'Modelli'                          : '',
-    'Zene'                             : '',
-    'Letöltések'                       : '',
-    'Számítógép'                       : '',
-    'Videók'                           : '',
-# Chinese(Simple)
-    '桌面'                             : '',
-    '文档'                             : '',
-    '下载'                             : '',
-    '音乐'                             : '',
-    '图片'                             : '',
-    '公共的'                           : '',
-    '公共'                           : '',
-    '模板'                             : '',
-    '视频'                             : '',
-# Chinese(Traditional)
-    '桌面'                             : '',
-    '文檔'                             : '',
-    '下載'                             : '',
-    '音樂'                             : '',
-    '圖片'                             : '',
-    '公共的'                           : '',
-    '公共'                           : '',
-    '模板'                             : '',
-    '視頻'                             : '',
-# Swedish
-    'Skrivbord'                          : '',
-    'Dokument'                        : '',
-    'Hämtningar'                        : '',
-    'Musik'                            : '',
-    'Bilder'                         : '',
-    'Public'                           : '',
-    'Mallar'                        : '',
-    'Video'                           : '',
-}
-
 # Python 2.x-3.4 don't support unpacking syntex `{**dict}`
 # XDG_USER_DIRS
 dir_node_exact_matches.update(xdgs_dirs)
@@ -450,6 +365,10 @@ file_node_exact_matches = {
 
 def devicon(file):
     if file.is_directory:
-        return dir_node_exact_matches.get(file.relative_path, '')
+        if current_locale != 'en':
+            english_name = current_locale_data['directory_mappings'].get(file.relative_path)
+            if english_name:
+                return english_locale_data['directory_mappings'].get(english_name, '')
+        return english_locale_data['directory_mappings'].get(file.relative_path, '')
     return file_node_exact_matches.get(os.path.basename(file.relative_path),
                                        file_node_extensions.get(file.extension, ''))

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -1,0 +1,8 @@
+de:
+  directory_mappings:
+    'Bilder': 'Pictures'
+    'Dokumente': 'Documents'
+    'Musik': 'Music'
+    'Schreibtisch': 'Desktop'
+    'Vorlagen': 'Templates'
+    'Öffentlich': 'Public'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,17 @@
+en:
+  directory_mappings:
+    '.git': ''
+    'Desktop': ''
+    'Documents': ''
+    'Downloads': ''
+    'Dotfiles': ''
+    'Dropbox': ''
+    'Music': ''
+    'Pictures': ''
+    'Public': ''
+    'Templates': ''
+    'Videos': ''
+    'anaconda3': ''
+    'go': ''
+    'workspace': ''
+    'OneDrive': ''

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -1,0 +1,10 @@
+es:
+  directory_mappings:
+    'Escritorio': 'Desktop'
+    'Documentos': 'Documents'
+    'Descargas': 'Downloads'
+    'Música': 'Music'
+    'Imágenes': 'Pictures'
+    'Público': 'Public'
+    'Plantillas': 'Templates'
+    'Vídeos': 'Videos'

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -1,0 +1,9 @@
+fr:
+  directory_mappings:
+    'Bureau': 'Desktop'
+    'Documents': 'Documents'
+    'Images': 'Pictures'
+    'Musique': 'Music'
+    'Publique': 'Public'
+    'Téléchargements': 'Downloads'
+    'Vidéos': 'Videos'

--- a/locales/hu.yml
+++ b/locales/hu.yml
@@ -1,0 +1,9 @@
+hu:
+  directory_mappings:
+    'Dokumentumok': 'Documents'
+    'Képek': 'Pictures'
+    'Modelli': 'Templates'
+    'Zene': 'Music'
+    'Letöltések': 'Downloads'
+    'Számítógép': 'Desktop'
+    'Videók': 'Videos'

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -1,0 +1,10 @@
+it:
+  directory_mappings:
+    'Documenti': 'Documents'
+    'Immagini': 'Pictures'
+    'Modelli': 'Templates'
+    'Musica': 'Music'
+    'Pubblici': 'Public'
+    'Scaricati': 'Downloads'
+    'Scrivania': 'Desktop'
+    'Video': 'Videos'

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -1,0 +1,9 @@
+pt:
+  directory_mappings:
+    'Documentos': 'Documents'
+    'Imagens': 'Pictures'
+    'Modelos': 'Templates'
+    'Música': 'Music'
+    'Público': 'Public'
+    'Vídeos': 'Videos'
+    'Área de trabalho': 'Desktop'

--- a/locales/sv.yml
+++ b/locales/sv.yml
@@ -1,0 +1,10 @@
+sv:
+  directory_mappings:
+    'Skrivbord': 'Desktop'
+    'Dokument': 'Documents'
+    'Hämtningar': 'Downloads'
+    'Musik': 'Music'
+    'Bilder': 'Pictures'
+    'Public': 'Public'
+    'Mallar': 'Templates'
+    'Video': 'Videos'

--- a/locales/zh_CN.yml
+++ b/locales/zh_CN.yml
@@ -1,0 +1,11 @@
+zh_CN:
+  directory_mappings:
+    '桌面': 'Desktop'
+    '文档': 'Documents'
+    '下载': 'Downloads'
+    '音乐': 'Music'
+    '图片': 'Pictures'
+    '公共的': 'Public'
+    '公共': 'Public'
+    '模板': 'Templates'
+    '视频': 'Videos'

--- a/locales/zh_TW.yml
+++ b/locales/zh_TW.yml
@@ -1,0 +1,11 @@
+zh_TW:
+  directory_mappings:
+    '桌面': 'Desktop'
+    '文檔': 'Documents'
+    '下載': 'Downloads'
+    '音樂': 'Music'
+    '圖片': 'Pictures'
+    '公共的': 'Public'
+    '公共': 'Public'
+    '模板': 'Templates'
+    '視頻': 'Videos'


### PR DESCRIPTION
Fixes #122

Add locale support for directory name to icon mappings

* **Locales**: Add new locale files for English, Italian, Spanish, French, Portuguese, German, Hungarian, Chinese (Simplified), Chinese (Traditional), and Swedish with directory mappings.
* **devicons.py**: Remove hardcoded directory name to icon mappings. Add logic to retrieve the locale file for the current locale and the English locale. Modify the `devicon` function to lookup `file.relative_path` inside the current locale and the English locale.
* **README.md**: Update documentation to reflect the changes made to use I18n for directory mappings. Add instructions on how to add new locale files.
* **CONTRIBUTING.MD**: Update contributing guidelines to reflect the changes made to use I18n for directory mappings. Add instructions on how to add new locale files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alexanderjeurissen/ranger_devicons/pull/123?shareId=2effd547-4e34-488a-aae3-a47cf773b2e7).