### PR TITLE
Fix shebang in devicons

### DIFF
--- a/devicons.py
+++ b/devicons.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # coding=UTF-8
 # These glyphs, and the mapping of file extensions to glyphs
 # has been copied from the vimscript code that is present in


### PR DESCRIPTION
## Summary
- ensure devicons.py uses a python3 env shebang

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683a1e496588832f8adcc7e8fcf14492