### PR TITLE
Add CI tests without ranger dependency

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,20 @@
+name: Python tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ This plugin can be configured by setting environment variables (e.g. in your
 - `RANGER_DEVICONS_SEPARATOR` (default `" "`, i.e. a single space): The
   separator between icon and filename. Some terminals use the adjacent space to
   display a bigger icon, in which case this can be set to two spaces instead.
+
+## Running tests
+
+Install pytest and execute the test suite with [pytest](https://pytest.org):
+
+```bash
+pip install pytest
+pytest -q
+```

--- a/tests/test_devicons.py
+++ b/tests/test_devicons.py
@@ -1,0 +1,37 @@
+import os
+import importlib.util
+import pathlib
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "devicons",
+    pathlib.Path(__file__).resolve().parents[1] / "devicons.py",
+)
+devicons = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(devicons)
+
+class MockFile:
+    def __init__(self, path, is_directory=False):
+        self.relative_path = path
+        self.is_directory = is_directory
+        self.extension = os.path.splitext(path)[1][1:]
+
+
+def test_devicon_py_file():
+    file = MockFile('example.py')
+    assert devicons.devicon(file) == ''
+
+
+def test_devicon_readme():
+    file = MockFile('README.md')
+    assert devicons.devicon(file) == ''
+
+
+def test_devicon_directory_match():
+    file = MockFile('Documents', is_directory=True)
+    assert devicons.devicon(file) == ''
+
+
+def test_devicon_unknown():
+    file = MockFile('unknown.unknown')
+    assert devicons.devicon(file) == ''


### PR DESCRIPTION
## Summary
- load the `devicons` module directly in the tests so the `ranger` package isn't required
- document running tests quietly using `pytest -q`
- run the workflow's test step in quiet mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a1ee1b5bc832fbef4f077f76d4f0d