### PR TITLE
Add XDG mapping test

### DIFF
--- a/tests/test_xdg.py
+++ b/tests/test_xdg.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import importlib
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+
+def reload_devicons():
+    from ranger_devicons import devicons
+    importlib.reload(devicons)
+    return devicons
+
+
+def test_xdg_music_dir(monkeypatch):
+    monkeypatch.setenv("XDG_MUSIC_DIR", "/home/user/Music")
+    monkeypatch.setenv("XDG_UNKNOWN_DIR", "/home/user/Unknown")
+
+    devicons = reload_devicons()
+
+    assert devicons.dir_node_exact_matches.get("Music") == ""
+    assert "Unknown" not in devicons.dir_node_exact_matches


### PR DESCRIPTION
## Summary
- add `tests/test_xdg.py` with checks for XDG directory mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683afcf71b20832fb70c11f2d1784ddf