### PR TITLE
Add parametrized tests for various devicons

### DIFF
--- a/tests/test_devicons.py
+++ b/tests/test_devicons.py
@@ -58,3 +58,18 @@ def test_devicon_unknown():
     devicons = reload_devicons('es')
     file = MockFile('unknown.unknown')
     assert devicons.devicon(file) == ''
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("data.json", ""),
+        ("image.png", ""),
+        ("archive.tar", ""),
+        ("Makefile", ""),
+        ("package.json", ""),
+    ],
+)
+def test_devicon_various_examples(name, expected):
+    devicons = reload_devicons('es')
+    assert devicons.devicon(MockFile(name)) == expected


### PR DESCRIPTION
## Summary
- expand test suite using `pytest.mark.parametrize`
- cover several common file extensions and names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683afd01ae74832f88187ee94ba24d48