### PR TITLE
Add default icon tests

### DIFF
--- a/tests/test_devicons.py
+++ b/tests/test_devicons.py
@@ -58,3 +58,17 @@ def test_devicon_unknown():
     devicons = reload_devicons('es')
     file = MockFile('unknown.unknown')
     assert devicons.devicon(file) == ''
+
+
+def test_unmapped_directory_returns_default(monkeypatch):
+    monkeypatch.setenv('XDG_DOWNLOAD_DIR', '/tmp/downloads')
+    devicons = reload_devicons('es')
+    file = MockFile('RandomDir', is_directory=True)
+    assert devicons.devicon(file) == ''
+
+
+def test_uncommon_extension_returns_default(monkeypatch):
+    monkeypatch.setenv('XDG_DOWNLOAD_DIR', '/tmp/downloads')
+    devicons = reload_devicons('es')
+    file = MockFile('file.xyz')
+    assert devicons.devicon(file) == ''


### PR DESCRIPTION
## Summary
- verify devicons fallback for unmapped directories
- verify devicons fallback for uncommon file extensions
- ensure env vars do not change these defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683afd048cac832f97c7a34132f79a31