### PR TITLE
Improve locale fallback test

### DIFF
--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -24,3 +24,14 @@ def test_load_translations_and_translate(monkeypatch):
 def test_load_translations_unknown(monkeypatch):
     monkeypatch.delenv('DEVICONS_LANG', raising=False)
     assert devicons.load_translations('unknown') == {}
+
+
+def test_locale_used_when_env_unset(monkeypatch):
+    """Translations fall back to the system locale when DEVICONS_LANG is unset."""
+    monkeypatch.delenv('DEVICONS_LANG', raising=False)
+    monkeypatch.setattr('locale.getdefaultlocale', lambda: ('fr_FR', 'UTF-8'))
+
+    importlib.reload(devicons)
+
+    assert devicons.dir_name_translations == fr.translations
+    assert devicons.load_translations() == fr.translations


### PR DESCRIPTION
## Summary
- rename locale-based test for clarity
- remove stray submodule entry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6841933a7824832fbe54d29b49bb036f